### PR TITLE
Spruce up travis builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ addons:
 before_install:
 - chef --version
 - eval "$(chef shell-init bash)"
-install:
-- chef gem install coveralls
+install: true
 jobs:
   include:
   - stage: verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ install:
 jobs:
   include:
   - stage: verify
-    script: delivery local verify
+    script: chef exec delivery local verify
   - stage: acceptance
-    script: delivery local acceptance
+    script: chef exec delivery local acceptance
   # TODO: Add the Chef Server key for trubot (~/.chef/trubot.pem)
   # - stage: Publish to Supermarket
   #   script: echo "Uploading to Supermarket..."

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@
 dist: trusty
 sudo: false
 language: ruby
+if: "((tag =~ ^v) AND (branch = master)) OR type = pull_request"
 cache:
   directories:
   - "$HOME/.berkshelf"

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 - chef --version
 - eval "$(chef shell-init bash)"
 install:
-- chef gem install coveralls -v '0.8.19'
+- chef gem install coveralls
 jobs:
   include:
   - stage: verify

--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # mcrouter
 [![Build Status](https://travis-ci.org/evertrue/mcrouter-cookbook.svg)](https://travis-ci.org/evertrue/mcrouter-cookbook)
-[![Coverage Status](https://coveralls.io/repos/github/evertrue/mcrouter-cookbook/badge.svg?branch=master)](https://coveralls.io/github/evertrue/mcrouter-cookbook?branch=master)
 
 Install [mcrouter](https://github.com/facebook/mcrouter) and its dependencies, and provide mechanisms to configure and start mcrouter.
 

--- a/recipes/_deps.rb
+++ b/recipes/_deps.rb
@@ -16,7 +16,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-include_recipe 'build-essential'
+apt_update
+build_essential 'mcrouter'
 
 %w(
   automake

--- a/recipes/folly.rb
+++ b/recipes/folly.rb
@@ -25,13 +25,13 @@ end
 
 execute 'build_folly' do
   command 'autoreconf -ivf && ./configure && make'
-  cwd file_cache_path 'folly', 'folly'
+  cwd file_cache_path('folly', 'folly')
   action :nothing
 end
 
 execute 'install_folly' do
   command 'make install'
-  cwd file_cache_path 'folly', 'folly'
+  cwd file_cache_path('folly', 'folly')
   creates '/usr/local/lib/libfolly.so'
   action :nothing
   notifies :run, 'execute[rebuild_ld_so_cache]', :immediately
@@ -48,7 +48,7 @@ end
 # We have to use a "unique" resource name here because `ark` above already has
 # a directory resource with this path as its name.
 directory 'delete folly build directory' do
-  path      file_cache_path 'folly', 'folly'
+  path      file_cache_path('folly', 'folly')
   action    :delete
   recursive true
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -20,13 +20,13 @@ include_recipe 'mcrouter::folly'
 
 execute 'build_mcrouter' do
   command 'autoreconf --install && ./configure && make'
-  cwd file_cache_path 'mcrouter', 'mcrouter'
+  cwd file_cache_path('mcrouter', 'mcrouter')
   action :nothing
 end
 
 execute 'install_mcrouter' do
   command 'make install'
-  cwd file_cache_path 'mcrouter', 'mcrouter'
+  cwd file_cache_path('mcrouter', 'mcrouter')
   creates '/usr/local/bin/mcrouter'
   action :nothing
 end
@@ -42,7 +42,7 @@ end
 # We have to use a "unique" resource name here because `ark` above already has
 # a directory resource with this path as its name.
 directory 'delete mcrouter build directory' do
-  path      file_cache_path 'mcrouter', 'mcrouter'
+  path      file_cache_path('mcrouter', 'mcrouter')
   recursive true
   action    :delete
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,9 +1,5 @@
 require 'chefspec'
 require 'chefspec/berkshelf'
-require 'coveralls'
-
-# Report coverage to Coveralls
-Coveralls.wear!
 
 # Generate a report
 ChefSpec::Coverage.start!


### PR DESCRIPTION
* Add `delivery local` config
* Use kitchen-dokken for acceptance tests
    - Drop unnecessary EC2-based secrets & so forth
* Drop specifying a Ruby version; ChefDK brings its own
* Use the right ChefDK APT source for a Trusty build env
* Use Chef Delivery commands & collapse build steps to speed up builds
    - Verify tests are run as a single stage to speed things up